### PR TITLE
Add auto font scaling to REPOLabel

### DIFF
--- a/MenuLib/MonoBehaviors/REPOLabel.cs
+++ b/MenuLib/MonoBehaviors/REPOLabel.cs
@@ -5,21 +5,61 @@ namespace MenuLib.MonoBehaviors;
 
 public sealed class REPOLabel : REPOElement
 {
-    public TextMeshProUGUI labelTMP;
-    
-    private void Awake()
-    {
-        rectTransform = (RectTransform) transform;
-        labelTMP = GetComponentInChildren<TextMeshProUGUI>();
+	public TextMeshProUGUI labelTMP;
+	public float maxFontSize = 30f;
+	public float minFontSize = 20f;
+	public bool autoScaleToFit = true;
 
-        labelTMP.rectTransform.pivot = rectTransform.pivot = Vector2.zero;
-        labelTMP.rectTransform.sizeDelta = rectTransform.sizeDelta = new Vector2(200f, 30f);
-        
-        labelTMP.fontSize = 30;
-        labelTMP.enableWordWrapping = labelTMP.enableAutoSizing = false;
-        labelTMP.alignment = TextAlignmentOptions.Left;
-        labelTMP.margin = Vector4.zero;
-    }
+	private void Awake()
+	{
+		rectTransform = (RectTransform)transform;
+		labelTMP = GetComponentInChildren<TextMeshProUGUI>();
 
-    private void Start() => labelTMP.rectTransform.localPosition = Vector2.zero;
+		labelTMP.rectTransform.pivot = rectTransform.pivot = Vector2.zero;
+		labelTMP.rectTransform.sizeDelta = rectTransform.sizeDelta = new Vector2(200f, 30f);
+
+		labelTMP.enableAutoSizing = false;
+		labelTMP.fontSize = maxFontSize;
+
+		labelTMP.enableWordWrapping = false;
+		labelTMP.alignment = TextAlignmentOptions.Left;
+		labelTMP.margin = Vector4.zero;
+	}
+
+	private void Start()
+	{
+		labelTMP.rectTransform.localPosition = Vector2.zero;
+
+		if (autoScaleToFit)
+		{
+			ScaleFontToFit();
+		}
+	}
+
+	public void ScaleFontToFit()
+	{
+		labelTMP.fontSize = maxFontSize;
+		labelTMP.ForceMeshUpdate();
+
+		var textBounds = labelTMP.textBounds;
+		var rectWidth = labelTMP.rectTransform.rect.width;
+
+		if (textBounds.size.x > rectWidth)
+		{
+			float scaleFactor = rectWidth / textBounds.size.x;
+			float newSize = Mathf.Max(minFontSize, maxFontSize * scaleFactor * 0.95f);
+			labelTMP.fontSize = newSize;
+			labelTMP.ForceMeshUpdate();
+		}
+	}
+
+	public void SetText(string text, bool scaleToFit = true)
+	{
+		labelTMP.text = text;
+
+		if (scaleToFit)
+		{
+			ScaleFontToFit();
+		}
+	}
 }


### PR DESCRIPTION
Hey! I've made small additions to add auto font scaling to `REPOLabel` so text stays within bounds and no longer runs "off-screen" in **REPOConfig**, maybe i should've made a pr with these changes to that Repository instead, i hope its okay i did it here.
(this annoyed me alot).

**Changes**:
- Added `minFontSize`, `maxFontSize`, and an `autoScaleToFit` toggle
- Implemented `ScaleFontToFit()` to adjust font size based on available width
- Added a `SetText()` helper with optional scaling

Let me know if there are any issues with this i missed, but it worked as i intended it to (see example images).
> I know `enableAutoSizing` exists, but its scaling tends to be too aggressive (imo), which is why I went with this approach instead.

**Before:**
<img width="798" height="416" alt="image" src="https://github.com/user-attachments/assets/f7ef594a-dc91-4bf3-aa8f-9c8f12c527de" />

**After:**
<img width="784" height="361" alt="image" src="https://github.com/user-attachments/assets/f586aa36-783c-4eda-9c4a-bf030b54a878" />

