### PR TITLE
Fix addedPageOOnTop being set to false unconditionally in OpenPageMenu

### DIFF
--- a/MenuLib/MenuAPI.cs
+++ b/MenuLib/MenuAPI.cs
@@ -329,7 +329,7 @@ public static class MenuAPI
         MenuManager.instance.PageAdd(menuPage);
         menuPage.StartCoroutine(REPOReflection.menuPage_LateStart.Invoke(menuPage, null) as IEnumerator);
 
-        REPOReflection.menuPage_AddedPageOnTop.SetValue(menuPage, false);
+        REPOReflection.menuPage_AddedPageOnTop.SetValue(menuPage, pageOnTop);
         
         if (!pageOnTop)
         {


### PR DESCRIPTION
Ran into this debugging my own mod. Slider arrows wouldn't hover or click on a page opened with `OpenPage(true)`, but the bar drag still worked, which was the weird part.

Tracked it to `MenuLib/MenuAPI.cs` line 332:

```csharp
REPOReflection.menuPage_AddedPageOnTop.SetValue(menuPage, false);
```

That's hardcoded false, but two lines down (in the `pageOnTop=true` branch) the page gets added to `addedPagesOnTop`. So the field should match the parameter:

```csharp
REPOReflection.menuPage_AddedPageOnTop.SetValue(menuPage, pageOnTop);
```

Why it specifically kills slider arrows: `MenuManager.Update` only calls `RegisterHover` on MenuButtons whose parentPage either has `addedPageOnTop=true` or isn't in Inactive/Closing state. A page opened with `pageOnTop=true` ends up with `addedPageOnTop=false` because of this line, and since `REPOPopupPage` uses `menuPageIndex=-1`, `StateActive` flips it to Inactive on the next frame. Both halves of the filter fail, so the page's MenuButtons get skipped forever.

REPOButton / Toggle / Label aren't affected because they run their own hover loops. REPOSlider's `<` and `>` are stock game MenuButtons inherited from the prefab, so they go completely dead. The bar still works because `REPOSlider.Update` calls `UIMouseHover` directly.

Repro:

```csharp
var page = MenuAPI.CreateREPOPopupPage("X", shouldCachePage: true);
page.AddElementToScrollView(sv => MenuAPI.CreateREPOSlider("S", "", v => {}, sv,
    min: 0, max: 10, defaultValue: 5).rectTransform);
page.OpenPage(openOnTop: true);
// hover < or >, nothing happens
// OpenPage(openOnTop: false) and they immediately work
```

Workaround if anyone hits this before a release: `page.menuPage.addedPageOnTop = true` right after `OpenPage(true)`.
