### PR TITLE
Changes:

### DIFF
--- a/MenuLib/MenuLib.csproj
+++ b/MenuLib/MenuLib.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<GameBaseDir>E:\SteamLibrary\steamapps\common\REPO</GameBaseDir>
-		<GameAssemblyDir>$(GameBaseDir)\REPO_Data\Managed</GameAssemblyDir>
+		<GameBaseDir>/home/kaede159/.local/share/Steam/steamapps/common/REPO</GameBaseDir>
+		<GameAssemblyDir>$(GameBaseDir)/REPO_Data/Managed</GameAssemblyDir>
 		<AssemblyVersion>2.5.3</AssemblyVersion>
 	</PropertyGroup>
 

--- a/MenuLib/MenuLib.csproj
+++ b/MenuLib/MenuLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<GameBaseDir>/home/kaede159/.local/share/Steam/steamapps/common/REPO</GameBaseDir>
+		<GameBaseDir>C:\SteamLibrary\steamapps\common\REPO</GameBaseDir>
 		<GameAssemblyDir>$(GameBaseDir)/REPO_Data/Managed</GameAssemblyDir>
 		<AssemblyVersion>2.5.3</AssemblyVersion>
 	</PropertyGroup>

--- a/MenuLib/MonoBehaviors/REPOButton.cs
+++ b/MenuLib/MonoBehaviors/REPOButton.cs
@@ -36,6 +36,8 @@ public sealed class REPOButton : REPOElement
         rectTransform = transform as RectTransform;
         button = GetComponent<Button>();
         menuButton = GetComponent<MenuButton>();
+        if (menuButton != null)
+            REPOReflection.menuButton_RectTransform.SetValue(menuButton, rectTransform);
         labelTMP = GetComponentInChildren<TextMeshProUGUI>();
         
         button.onClick = new Button.ButtonClickedEvent();

--- a/MenuLib/REPOReflection.cs
+++ b/MenuLib/REPOReflection.cs
@@ -15,6 +15,7 @@ public static class REPOReflection
     public static readonly FieldInfo menuPage_CurrentPageState = AccessTools.Field(typeof(MenuPage), "currentPageState");
     public static readonly FieldInfo menuPage_AnimateAwayPosition = AccessTools.Field(typeof(MenuPage), "animateAwayPosition");
     public static readonly FieldInfo menuButton_ParentPage = AccessTools.Field(typeof(MenuButton), "parentPage");
+    public static readonly FieldInfo menuButton_RectTransform = AccessTools.Field(typeof(MenuButton), "rectTransform");
     public static readonly FieldInfo menuScrollBox_ScrollerEndPosition = AccessTools.Field(typeof(MenuScrollBox), "scrollerEndPosition");
     public static readonly FieldInfo menuScrollBox_ScrollerStartPosition = AccessTools.Field(typeof(MenuScrollBox), "scrollerStartPosition");
     public static readonly FieldInfo menuScrollBox_ScrollHandleTargetPosition = AccessTools.Field(typeof(MenuScrollBox), "scrollHandleTargetPosition");


### PR DESCRIPTION
    - Fix: MenuButton.rectTransform is now explicitly assigned from REPOButton.Awake() — prevents NullReferenceException in SemiFunc.UIGetRectTransformPositionOnScreen when hovering over admin menu buttons. This occurs because in recent game versions, MenuButton.Awake() does not guarantee the rectTransform field is initialized in time.